### PR TITLE
terminology testing server - added PUT library test

### DIFF
--- a/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
+++ b/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
@@ -8693,95 +8693,61 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "//NOTE: this test uses a PUT instead of a POST. Otherwise you get an error: 'A Manifest with the same id or url already exists.' after 1 POST",
+                      "// Based on source of truth: SOT@ https://github.com/cqframework/ecqm-content-qicore-2024-subset/blob/main/input/resources/library/Manifest-Final-Draft.json @SOT",
                       "",
                       "pm.test(\"Response status code is 200 or 201\", function () {",
                       "    pm.expect(pm.response.code).to.oneOf([200, 201]);",
                       "});",
                       "",
-                      "",
-                      "pm.test(\"Resource Type should not be empty\", function () {",
                       "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.resourceType).to.exist.and.to.not.be.empty;",
                       "    if (pm.environment.get(\"QUALITY_PROGRAM_DEBUG\") === true){",
                       "       console.log(responseData);",
                       "    }",
+                      "",
+                      "pm.test(\"Resource Type should be Library\", function () {",
+                      "    const responseData = pm.response.json();",
+                      "    pm.expect(responseData.resourceType).to.equal(\"Library\");",
                       "});",
                       "",
-                      "pm.test(\"Resource Type should be transaction-response\", function (){",
+                      "pm.test(\"Test that id is Manifest-Final-Draft\", function () {",
                       "    const responseData = pm.response.json();",
                       "",
-                      "    pm.expect(responseData.type).to.exist.and.to.not.be.empty;",
-                      "})",
-                      "",
-                      "",
-                      "pm.test(\"Test that id is not empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.id).to.exist.and.to.not.be.empty;",
-                      "});",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"draft\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"Test Logic Library\"\n    }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{SERVER_URL}}Library",
-                  "host": [
-                    "{{SERVER_URL}}Library"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Quality Program Release 8.2 Update Draft",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Response status code is 200 or 201\", function () {",
-                      "    pm.expect(pm.response.code).to.oneOf([200, 201]);",
+                      "    pm.expect(responseData.id).to.equal(\"Manifest-Final-Draft\");",
                       "});",
                       "",
-                      "",
-                      "pm.test(\"Resource Type should not be empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.resourceType).to.exist.and.to.not.be.empty;",
-                      "    if (pm.environment.get(\"QUALITY_PROGRAM_DEBUG\") === true){",
-                      "       console.log(responseData);",
-                      "    }",
+                      "pm.test(\"Contains system-version 'http://loinc.org|2.76'\", function () {",
+                      "const responseData = pm.response.json();",
+                      "const expParams = responseData.contained.find(",
+                      "r => r.resourceType === \"Parameters\" && r.id === \"exp-params\"",
+                      ");",
+                      "pm.expect(expParams).to.be.an(\"object\", \"exp-params not found\");",
+                      "const hasLoinc = expParams.parameter.some(",
+                      "p => p.name === \"system-version\" && p.valueUri === \"http://loinc.org|2.76\"",
+                      ");",
+                      "pm.expect(hasLoinc).to.be.true;",
                       "});",
                       "",
-                      "pm.test(\"Resource Type should be transaction-response\", function (){",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.type).to.exist.and.to.not.be.empty;",
-                      "})",
-                      "",
-                      "",
-                      "pm.test(\"Test that id is not empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.id).to.exist.and.to.not.be.empty;",
+                      "pm.test(\"Contains endpointUri 'https://uat-cts.nlm.nih.gov/fhir/'\", function () {",
+                      "const responseData = pm.response.json();",
+                      "const endpoints = responseData.contained.find(",
+                      "r => r.resourceType === \"Parameters\" && r.id === \"endpoints\"",
+                      ");",
+                      "pm.expect(endpoints).to.be.an(\"object\", \"endpoints not found\");",
+                      "const hasEndpoint = endpoints.parameter.some(config =>",
+                      "config.name === \"artifactEndpointConfiguration\" && config.part?.some(p =>",
+                      "p.name === \"endpointUri\" && p.valueUri === \"https://uat-cts.nlm.nih.gov/fhir/\")",
+                      ");",
+                      " pm.expect(hasEndpoint).to.be.true;",
                       "});",
-                      ""
+                      "",
+                      "pm.test(\"Contains relatedArtifact 'Hospital Harm - Severe Hyperglycemia' measure\", function () {",
+                      "const responseData = pm.response.json();",
+                      "const hasArtifact = responseData.relatedArtifact?.some(artifact =>",
+                      "artifact.resource === \"https://madie.cms.gov/Measure/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR|0.1.000\"",
+                      ");",
+                      "pm.expect(hasArtifact).to.be.true;",
+                      "});"
                     ],
                     "type": "text/javascript"
                   }
@@ -8792,7 +8758,7 @@
                 "header": [],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"draft\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"Test Logic Library, test using PUT to update\"\n    }\n}",
+                  "raw": "{\"resourceType\":\"Library\",\"id\":\"Manifest-Final-Draft\",\"meta\":{\"profile\":[\"http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary\"]},\"contained\":[{\"resourceType\":\"Parameters\",\"id\":\"exp-params\",\"parameter\":[{\"name\":\"system-version\",\"valueUri\":\"http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901\"},{\"name\":\"system-version\",\"valueUri\":\"http://loinc.org|2.76\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/CD2|2.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"urn:oid:2.16.840.1.113883.6.238|1.2\"},{\"name\":\"system-version\",\"valueUri\":\"http://www.ama-assn.org/go/cpt|3.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"http://hl7.org/fhir/sid/cvx|4.0.0\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/HCPCS-all-codes|3.0.0\"},{\"name\":\"system-version\",\"valueUri\":\"http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|1.0.2\"},{\"name\":\"system-version\",\"valueUri\":\"http://hl7.org/fhir/sid/icd-10-cm|2.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"http://www.cms.gov/Medicare/Coding/ICD10|2.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/icd9cm|2.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"http://terminology.hl7.org/CodeSystem/v2-0895|2.2.0\"},{\"name\":\"system-version\",\"valueUri\":\"http://www.nlm.nih.gov/research/umls/rxnorm|3.0.1\"},{\"name\":\"system-version\",\"valueUri\":\"https://nahdo.org/sopt|1.0.1\"}]},{\"resourceType\":\"Parameters\",\"id\":\"endpoints\",\"parameter\":[{\"name\":\"artifactEndpointConfiguration\",\"part\":[{\"name\":\"artifactRoute\",\"valueUri\":\"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167|20220820\"},{\"name\":\"endpointUri\",\"valueUri\":\"https://example.org/fhir/\"}]},{\"name\":\"artifactEndpointConfiguration\",\"part\":[{\"name\":\"artifactRoute\",\"valueUri\":\"http://cts.nlm.nih.gov/fhir/\"},{\"name\":\"endpointUri\",\"valueUri\":\"https://uat-cts.nlm.nih.gov/fhir/\"}]},{\"name\":\"artifactEndpointConfiguration\",\"part\":[{\"name\":\"artifactRoute\",\"valueUri\":\"http://terminology.hl7.org/\"},{\"name\":\"endpointUri\",\"valueUri\":\"https://tx.fhir.org/r4/\"}]},{\"name\":\"artifactEndpointConfiguration\",\"part\":[{\"name\":\"artifactRoute\",\"valueUri\":\"http://hl7.org/fhir/\"},{\"name\":\"endpointUri\",\"valueUri\":\"https://tx.fhir.org/r4/\"}]}]}],\"extension\":[{\"url\":\"http://hl7.org/fhir/StructureDefinition/cqf-expansionParameters\",\"valueReference\":{\"reference\":\"#exp-params\"}},{\"url\":\"http://hl7.org/fhir/StructureDefinition/cqf-endpointConfiguration\",\"valueReference\":{\"reference\":\"#endpoints\"}}],\"url\":\"http://hl7.org/fhir/us/cqfmeasures/Library/ecqm-update-2024\",\"identifier\":[{\"use\":\"official\",\"system\":\"http://example.org/fhir/cqi/ecqm/Library/Identifier\",\"value\":\"eCQM Update 2024\"}],\"version\":\"1.0.0\",\"name\":\"ECQMUpdate2024\",\"title\":\"eCQM Update 2024\",\"status\":\"draft\",\"experimental\":true,\"type\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/library-type\",\"code\":\"asset-collection\"}]},\"date\":\"2024-04-23\",\"publisher\":\"Clinical Quality Information WG\",\"contact\":[{\"telecom\":[{\"system\":\"url\",\"value\":\"http://www.hl7.org/Special/committees/cqi\"}]}],\"description\":\"This library is an example final draft of a version manifest (also referred to as an expansion profile) that specifies expansion rules for a set of value sets used for an example set of EP/EC measures.\",\"jurisdiction\":[{\"coding\":[{\"system\":\"urn:iso:std:iso:3166\",\"code\":\"US\"}]}],\"purpose\":\"This library is defined to illustrate a Version Manifest in final draft status, as it would look at the end of an eCQM Annual Update cycle, approved on April 23rd, 2024. The latest available version of code systems used at that time is specified to provide stability for value set expansion during the testing and implementation phase. Terminology.HL7.org, in particular, was version 5.5.0 at the time, and FHIR code system versions are chosen from that release.\",\"approvalDate\":\"2024-04-23\",\"lastReviewDate\":\"2024-04-23\",\"relatedArtifact\":[{\"type\":\"composed-of\",\"display\":\"Measure Discharged on Antithrombotic TherapyFHIR, 0.9.000\",\"resource\":\"https://madie.cms.gov/Measure/DischargedonAntithromboticTherapyFHIR|0.9.000\"},{\"type\":\"composed-of\",\"display\":\"Measure Global Malnutrition CompositeFHIR, 0.2.000\",\"resource\":\"https://madie.cms.gov/Measure/GlobalMalnutritionCompositeFHIR|0.2.000\"},{\"type\":\"composed-of\",\"display\":\"Measure HIV ScreeningFHIR, 0.2.000\",\"resource\":\"https://madie.cms.gov/Measure/HIVScreeningFHIR|0.2.000\"},{\"type\":\"composed-of\",\"display\":\"Measure Hospital Harm - Severe HyperglycemiaFHIR, 0.1.000\",\"resource\":\"https://madie.cms.gov/Measure/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR|0.1.000\"},{\"type\":\"composed-of\",\"display\":\"Measure Core Clinical Data Elements for the Hybrid Hospital Wide All Condition All Procedure Risk Standardized Mortality Measure HWMFHIR, 0.0.001\",\"resource\":\"https://madie.cms.gov/Measure/HybridHospitalWideMortalityFHIR|0.0.001\"},{\"type\":\"composed-of\",\"display\":\"Measure Primary Caries Prevention Intervention as Offered by DentistsFHIR, 0.0.002\",\"resource\":\"https://madie.cms.gov/Measure/PrimaryCariesPreventionasOfferedbyDentistsFHIR|0.0.002\"},{\"type\":\"composed-of\",\"display\":\"Measure Severe Obstetric ComplicationsFHIR, 0.1.000\",\"resource\":\"https://madie.cms.gov/Measure/SevereObstetricComplicationsFHIR|0.1.000\"}]}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -8800,219 +8766,9 @@
                   }
                 },
                 "url": {
-                  "raw": "{{SERVER_URL}}Library/postLibraryTest",
+                  "raw": "{{SERVER_URL}}Library/Manifest-Final-Draft",
                   "host": [
-                    "{{SERVER_URL}}Library"
-                  ],
-                  "path": [
-                    "postLibraryTest"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Quality Program Release 8.3 Release Library",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Response status code is 200\", function () {",
-                      "    pm.expect(pm.response.code).equals(\"200\");",
-                      "});",
-                      "",
-                      "",
-                      "pm.test(\"Resource Type should not be empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.resourceType).to.exist.and.to.not.be.empty;",
-                      "    if (pm.environment.get(\"QUALITY_PROGRAM_DEBUG\") === true){",
-                      "       console.log(responseData);",
-                      "    }",
-                      "});",
-                      "",
-                      "pm.test(\"Resource Type should be transaction-response\", function (){",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.type).to.exist.and.to.not.be.empty;",
-                      "})",
-                      "",
-                      "pm.test(\"Test that id is not empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.id).to.exist.and.to.not.be.empty;",
-                      "});",
-                      "",
-                      "pm.test(\"Status is active\", function (){",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.status).equals(\"active\");",
-                      "})",
-                      "",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "PUT",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"active\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"Test Logic Library, test using PUT to update\"\n    }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{SERVER_URL}}Library/postLibraryTest",
-                  "host": [
-                    "{{SERVER_URL}}Library"
-                  ],
-                  "path": [
-                    "postLibraryTest"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Quality Program Release 8.4 Retire Library",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Response status code is 200\", function () {",
-                      "    pm.expect(pm.response.code).equals(\"200\");",
-                      "});",
-                      "",
-                      "",
-                      "pm.test(\"Resource Type should not be empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.resourceType).to.exist.and.to.not.be.empty;",
-                      "    if (pm.environment.get(\"QUALITY_PROGRAM_DEBUG\") === true){",
-                      "       console.log(responseData);",
-                      "    }",
-                      "});",
-                      "",
-                      "pm.test(\"Resource Type should be transaction-response\", function (){",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.type).to.exist.and.to.not.be.empty;",
-                      "})",
-                      "",
-                      "pm.test(\"Test that id is not empty\", function () {",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.id).to.exist.and.to.not.be.empty;",
-                      "});",
-                      "",
-                      "pm.test(\"Status is retired\", function (){",
-                      "    const responseData = pm.response.json();",
-                      "",
-                      "    pm.expect(responseData.status).equals(\"retired\");",
-                      "})",
-                      "",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "PUT",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"retired\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"Test Logic Library, test using PUT to update\"\n    }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{SERVER_URL}}Library/postLibraryTest",
-                  "host": [
-                    "{{SERVER_URL}}Library"
-                  ],
-                  "path": [
-                    "postLibraryTest"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Quality Program Release 8.5 Libraries Immutable",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "",
-                      "pm.test(\"Response status code is NOT 200\", function () {",
-                      "    pm.expect(pm.response.code).not.equals(\"200\");",
-                      "    if (pm.environment.get(\"QUALITY_PROGRAM_DEBUG\") === true){",
-                      "       console.log(pm.response.json());",
-                      "    }",
-                      "});",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "PUT",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"active\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"test logic library should be rejected, because library is not in draft mode\"\n    }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{SERVER_URL}}Library/postLibraryTest",
-                  "host": [
-                    "{{SERVER_URL}}Library"
-                  ],
-                  "path": [
-                    "postLibraryTest"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Quality Program Release 8.6 Libraries Unique",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\n    \"resourceType\": \"Library\",\n    \"id\": \"postLibraryTest\",\n    \"title\": \"Post Library Test\",\n    \"status\": \"draft\",\n    \"version\": \"0.0.1\",\n    \"url\": \"postLibraryTest\",\n    \"type\": {\n        \"coding\": [\n            {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n                \"code\": \"logic-library\",\n                \"display\": \"Logic Library\"\n            }\n        ],\n        \"text\": \"Test Logic Library that should be rejected due to duplicate url and version\"\n    }\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{SERVER_URL}}Library",
-                  "host": [
-                    "{{SERVER_URL}}Library"
+                    "{{SERVER_URL}}Library/Manifest-Final-Draft"
                   ]
                 }
               },


### PR DESCRIPTION
This added Quality Program 8.1 to test the PUT/POST of a Library was working for VSAC earlier, but is currently getting an error: The Manifest does not exist

I think that is due to the VSAC uat server being readied for the connectathon.

This PR should only be used for the changes to cqf-measures-terminology-service-tests.postman_collection.json