### PR TITLE
VSAC testing update for manifest Library support

### DIFF
--- a/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
+++ b/postman-tests/collections/cqf-measures-terminology-service-tests.postman_collection.json
@@ -6570,15 +6570,79 @@
                   "response": []
                 },
                 {
-                  "name": "ValueSet 12.1.1 POST Expand on Id (Latest) with expansion profile using manifest",
+                  "name": "ValueSet 12.1.1 DELETE manifest library",
                   "event": [
                     {
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "//  NOTE: this uses a PUT right now because if the test is run once then the manifest exists on the server and a POST gives an error because of that",
-
-                          "//SOT@## ValueSet 12.1.1 POST @SOT",
+                          "//SOT@## ValueSet 12.1.1 DELETE manifest library @SOT",
+                          "// Based on source of truth: SOT@ TBD @SOT",
+                          "// successful Delete",
+                          "pm.test(\"Response status code is 204 No Content\", function () {\r",
+                          "    pm.expect(pm.response.code).to.equal(204);\r",
+                          "});\r"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "DELETE",
+                    "header": [],
+                    "url": {
+                      "raw": "{{SERVER_URL}}Library/ecqm-fhir-update-2025",
+                      "host": [
+                        "{{SERVER_URL}}Library/ecqm-fhir-update-2025"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "ValueSet 12.1.2 DELETE nonexisting manifest library",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "//SOT@## ValueSet 12.1.2 DELETE manifest library @SOT",
+                          "// Based on source of truth: SOT@ TBD @SOT",
+                          " const responseData = pm.response.json();\r",
+                          " const response_Code = pm.response.code;\r",
+                          " if (pm.environment.get(\"VALUESET_DEBUG\") === true){",
+                          "    console.log(responseData);",
+                          " }",
+                          "// successful Delete",
+                          "pm.test(\"Response status code is 404 Not Found\", function () {\r",
+                          "    pm.expect(response_Code).to.equal(404);\r",
+                          "});\r",
+                          "\r"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "DELETE",
+                    "header": [],
+                    "url": {
+                      "raw": "{{SERVER_URL}}Library/ecqm-fhir-update-2025",
+                      "host": [
+                        "{{SERVER_URL}}Library/ecqm-fhir-update-2025"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "ValueSet 12.1.3 POST Expand on Id (Latest) with expansion profile using manifest",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "//SOT@## ValueSet 12.1.3 POST @SOT",
                           "// Based on source of truth: SOT@ TBD @SOT",
                           " const responseData = pm.response.json();\r",
                           " const response_Code = pm.response.code;\r",
@@ -6644,7 +6708,7 @@
                     }
                   ],
                   "request": {
-                    "method": "PUT",
+                    "method": "POST",
                     "header": [],
                     "body": {
                       "mode": "raw",
@@ -6656,22 +6720,22 @@
                       }
                     },
                     "url": {
-                      "raw": "{{SERVER_URL}}Library/ecqm-fhir-update-2025",
+                      "raw": "{{SERVER_URL}}Library/",
                       "host": [
-                        "{{SERVER_URL}}Library/ecqm-fhir-update-2025"
+                        "{{SERVER_URL}}Library/"
                       ]
                     }
                   },
                   "response": []
                 },
                 {
-                  "name": "ValueSet 12.1.2 PUT modified manifest library",
+                  "name": "ValueSet 12.1.4 PUT modified manifest library",
                   "event": [
                     {
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "//SOT@## ValueSet 12.1.2 PUT modified manifest library @SOT",
+                          "//SOT@## ValueSet 12.1.4 PUT modified manifest library @SOT",
                           "// Based on source of truth: SOT@ TBD @SOT",
                           "const responseData = pm.response.json();",
                           "const response_Code = pm.response.code;",
@@ -6710,6 +6774,9 @@
                           "      pm.expect(jsonData.contained[0].resourceType).to.eql(\"Parameters\");",
                           "      pm.expect(jsonData.contained[0].id).to.eql(\"exp-params\");",
                           "    });",
+                          "    pm.test(\"Verify update of status to active happened\", function () {",
+                          "      pm.expect(jsonData.status).to.eql(\"active\");",
+                          "    });",
                           "  }",
                           "});"
                         ],
@@ -6723,7 +6790,86 @@
                     "header": [],
                     "body": {
                       "mode": "raw",
-                      "raw": "{\n\"resourceType\": \"Library\",\n\"id\": \"ecqm-fhir-update-2025\",\n\"meta\": {\n\"profile\": [\n\"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm\"\n]\n},\n\"contained\": [\n{\n\"resourceType\": \"Parameters\",\n\"id\": \"exp-params\",\n\"parameter\": [\n{\n\"name\": \"activeOnly\",\n\"valueBoolean\": true\n},\n{\n\"name\": \"includeDraft\",\n\"valueBoolean\": false\n},\n{\n\"name\": \"system-version\",\n\"valueCanonical\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0\",\n\"_valueCanonical\": {\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/StructureDefinition/display\",\n\"valueString\": \"ActCode, 9.0.0\"\n}\n]\n}\n}\n]\n}\n],\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-partOf\",\n\"valueCanonical\": \"http://hl7.org/fhir/us/cqfmeasures/Library/ecqm-quality-program\"\n}\n],\n\"url\": \"http://cts.nlm.nih.gov/fhir/Library/ecqm-fhir-update-2025\",\n\"identifier\": [\n{\n\"use\": \"official\",\n\"system\": \"http://cts.nlm.nih.gov/fhir/cqi/ecqm/Library/Identifier\",\n\"value\": \"ecqm-fhir-update-2025\"\n}\n],\n\"version\": \"1.0.0\",\n\"name\": \"eCQMFHIRUpdate2025\",\n\"title\": \"eCQM FHIR Update 2025\",\n\"status\": \"draft\",\n\"experimental\": false,\n\"type\": {\n\"coding\": [\n{\n\"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n\"code\": \"asset-collection\"\n}\n]\n},\n\"date\": \"2025-07-25\",\n\"publisher\": \"Centers for Medicare and Medicaid Services (CMS)\",\n\"contact\": [\n{\n\"telecom\": [\n{\n\"system\": \"url\",\n\"value\": \"https://www.cms.gov/\"\n}\n]\n}\n],\n\"description\": \"eCQM FHIR Update 2025 updated for PUT test\",\n\"useContext\": [\n{\n\"code\": {\n\"system\": \"http://terminology.hl7.org/CodeSystem/usage-context-type\",\n\"code\": \"program\"\n},\n\"valueCodeableConcept\": {\n\"coding\": [\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"ep-ec\",\n\"display\": \"EP/EC\"\n},\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"eh-cah\",\n\"display\": \"EH/CAH\"\n}\n]\n}\n}\n],\n\"jurisdiction\": [\n{\n\"coding\": [\n{\n\"system\": \"urn:iso:std:iso:3166\",\n\"code\": \"US\"\n}\n]\n}\n]\n}",
+                      "raw": "{\n\"resourceType\": \"Library\",\n\"id\": \"ecqm-fhir-update-2025\",\n\"meta\": {\n\"profile\": [\n\"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm\"\n]\n},\n\"contained\": [\n{\n\"resourceType\": \"Parameters\",\n\"id\": \"exp-params\",\n\"parameter\": [\n{\n\"name\": \"activeOnly\",\n\"valueBoolean\": true\n},\n{\n\"name\": \"includeDraft\",\n\"valueBoolean\": false\n},\n{\n\"name\": \"system-version\",\n\"valueCanonical\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0\",\n\"_valueCanonical\": {\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/StructureDefinition/display\",\n\"valueString\": \"ActCode, 9.0.0\"\n}\n]\n}\n}\n]\n}\n],\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-partOf\",\n\"valueCanonical\": \"http://hl7.org/fhir/us/cqfmeasures/Library/ecqm-quality-program\"\n}\n],\n\"url\": \"http://cts.nlm.nih.gov/fhir/Library/ecqm-fhir-update-2025\",\n\"identifier\": [\n{\n\"use\": \"official\",\n\"system\": \"http://cts.nlm.nih.gov/fhir/cqi/ecqm/Library/Identifier\",\n\"value\": \"ecqm-fhir-update-2025\"\n}\n],\n\"version\": \"1.0.0\",\n\"name\": \"eCQMFHIRUpdate2025\",\n\"title\": \"eCQM FHIR Update 2025\",\n\"status\": \"active\",\n\"experimental\": false,\n\"type\": {\n\"coding\": [\n{\n\"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n\"code\": \"asset-collection\"\n}\n]\n},\n\"date\": \"2025-07-25\",\n\"publisher\": \"Centers for Medicare and Medicaid Services (CMS)\",\n\"contact\": [\n{\n\"telecom\": [\n{\n\"system\": \"url\",\n\"value\": \"https://www.cms.gov/\"\n}\n]\n}\n],\n\"description\": \"eCQM FHIR Update 2025 updated for PUT test\",\n\"useContext\": [\n{\n\"code\": {\n\"system\": \"http://terminology.hl7.org/CodeSystem/usage-context-type\",\n\"code\": \"program\"\n},\n\"valueCodeableConcept\": {\n\"coding\": [\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"ep-ec\",\n\"display\": \"EP/EC\"\n},\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"eh-cah\",\n\"display\": \"EH/CAH\"\n}\n]\n}\n}\n],\n\"jurisdiction\": [\n{\n\"coding\": [\n{\n\"system\": \"urn:iso:std:iso:3166\",\n\"code\": \"US\"\n}\n]\n}\n]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{SERVER_URL}}Library/ecqm-fhir-update-2025",
+                      "host": [
+                        "{{SERVER_URL}}Library/ecqm-fhir-update-2025"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "ValueSet 12.1.5 DELETE manifest library with active status",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          "//SOT@## ValueSet 12.1.5 DELETE maifest library with active status @SOT",
+                          "// Based on source of truth: SOT@ TBD @SOT",
+                          " const responseData = pm.response.json();\r",
+                          " const response_Code = pm.response.code;\r",
+                          " if (pm.environment.get(\"VALUESET_DEBUG\") === true){",
+                          "    console.log(responseData);",
+                          " }",
+                          "// successful Delete",
+                          "pm.test(\"Response status code is 405 Method Not Allowed\", function () {\r",
+                          "    pm.expect(response_Code).to.equal(405);\r",
+                          "});\r",
+                          "\r"
+                        ],
+                        "type": "text/javascript"
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "DELETE",
+                    "header": [],
+                    "url": {
+                      "raw": "{{SERVER_URL}}Library/ecqm-fhir-update-2025",
+                      "host": [
+                        "{{SERVER_URL}}Library/ecqm-fhir-update-2025"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Cleanup of manifest library after testing",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "exec": [
+                          " const responseData = pm.response.json();\r",
+                          " const response_Code = pm.response.code;\r",
+                          " if (pm.environment.get(\"VALUESET_DEBUG\") === true){",
+                          "    console.log(responseData);",
+                          " }",
+                          "// Successful PUT",
+                          "pm.test(\"Response status code is 200\", function () {\r",
+                          "    pm.expect(response_Code).to.equal(200);\r",
+                          "});\r"
+                        ],
+                        "type": "text/javascript",
+                        "packages": {}
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "PUT",
+                    "header": [],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n\"resourceType\": \"Library\",\n\"id\": \"ecqm-fhir-update-2025\",\n\"meta\": {\n\"profile\": [\n\"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm\"\n]\n},\n\"contained\": [\n{\n\"resourceType\": \"Parameters\",\n\"id\": \"exp-params\",\n\"parameter\": [\n{\n\"name\": \"activeOnly\",\n\"valueBoolean\": true\n},\n{\n\"name\": \"includeDraft\",\n\"valueBoolean\": false\n},\n{\n\"name\": \"system-version\",\n\"valueCanonical\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0\",\n\"_valueCanonical\": {\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/StructureDefinition/display\",\n\"valueString\": \"ActCode, 9.0.0\"\n}\n]\n}\n}\n]\n}\n],\n\"extension\": [\n{\n\"url\": \"http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-partOf\",\n\"valueCanonical\": \"http://hl7.org/fhir/us/cqfmeasures/Library/ecqm-quality-program\"\n}\n],\n\"url\": \"http://cts.nlm.nih.gov/fhir/Library/ecqm-fhir-update-2025\",\n\"identifier\": [\n{\n\"use\": \"official\",\n\"system\": \"http://cts.nlm.nih.gov/fhir/cqi/ecqm/Library/Identifier\",\n\"value\": \"ecqm-fhir-update-2025\"\n}\n],\n\"version\": \"1.0.0\",\n\"name\": \"eCQMFHIRUpdate2025\",\n\"title\": \"eCQM FHIR Update 2025\",\n\"status\": \"draft\",\n\"experimental\": false,\n\"type\": {\n\"coding\": [\n{\n\"system\": \"http://terminology.hl7.org/CodeSystem/library-type\",\n\"code\": \"asset-collection\"\n}\n]\n},\n\"date\": \"2025-07-25\",\n\"publisher\": \"Centers for Medicare and Medicaid Services (CMS)\",\n\"contact\": [\n{\n\"telecom\": [\n{\n\"system\": \"url\",\n\"value\": \"https://www.cms.gov/\"\n}\n]\n}\n],\n\"description\": \"eCQM FHIR Update 2025\",\n\"useContext\": [\n{\n\"code\": {\n\"system\": \"http://terminology.hl7.org/CodeSystem/usage-context-type\",\n\"code\": \"program\"\n},\n\"valueCodeableConcept\": {\n\"coding\": [\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"ep-ec\",\n\"display\": \"EP/EC\"\n},\n{\n\"system\": \"http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs\",\n\"code\": \"eh-cah\",\n\"display\": \"EH/CAH\"\n}\n]\n}\n}\n],\n\"jurisdiction\": [\n{\n\"coding\": [\n{\n\"system\": \"urn:iso:std:iso:3166\",\n\"code\": \"US\"\n}\n]\n}\n]\n}",
                       "options": {
                         "raw": {
                           "language": "json"


### PR DESCRIPTION
addition of 12.1.* tests of DELETE, POST, PUT for manifest.
Last step here was to restore the Library to original condition.