### PR TITLE
FHIR-56819

### DIFF
--- a/input/cqm.xml
+++ b/input/cqm.xml
@@ -45,7 +45,7 @@
   <dependsOn id="crmi">
     <uri value="http://hl7.org/fhir/uv/crmi/ImplementationGuide/hl7.fhir.uv.crmi"/>
      <packageId value="hl7.fhir.uv.crmi"/>
-     <version value="2.0.0"/>
+     <version value="1.0.0"/>
   </dependsOn>
   <dependsOn id="cql">
     <uri value="http://hl7.org/fhir/uv/cql/ImplementationGuide/hl7.fhir.uv.cql"/>

--- a/input/cqm.xml
+++ b/input/cqm.xml
@@ -45,7 +45,7 @@
   <dependsOn id="crmi">
     <uri value="http://hl7.org/fhir/uv/crmi/ImplementationGuide/hl7.fhir.uv.crmi"/>
      <packageId value="hl7.fhir.uv.crmi"/>
-     <version value="1.0.0"/>
+     <version value="2.0.0"/>
   </dependsOn>
   <dependsOn id="cql">
     <uri value="http://hl7.org/fhir/uv/cql/ImplementationGuide/hl7.fhir.uv.cql"/>

--- a/input/pages/operations.md
+++ b/input/pages/operations.md
@@ -2,15 +2,17 @@
 
 {: #operations}
 
-This implementation guide defines operations related to packaging.
+This IG aligns with or makes use of operations from the [Canonical Resource Management Infrastructure (CRMI) Implementation Guide](https://hl7.org/fhir/uv/crmi/STU2/en/operations.html).
+
+When invoking the [$data-requirements](https://hl7.org/fhir/uv/crmi/STU2/en/OperationDefinition-crmi-data-requirements.html) operation for a Measure, periodStart and periodEnd are provided in the parameters parameter.
+
+For more information on packaging, dependency management, terminology and artifact authoring, see [Canonical Resource Management Infrastructure (CRMI) Implementation Guide](https://hl7.org/fhir/uv/crmi/STU2/en/index.html).
 
 ### Operations
 
 #### Packaging
 
-These operations are defined to support artifact packaging and dependency tracing, including data requirements determination. When invoking the $data-requirements operation for a Measure, periodStart and periodEnd are provided in the parameters parameter.
-See the [Packaging](packaging.html) discussion for more information.
-For more information on packaging, dependency management, terminology and artifact authoring, see [Canonical Resource Management Infrastructure (CRMI) Implementation Guide](https://hl7.org/fhir/uv/crmi/STU2/en/operations.html).
+QM IG defines the CQM Package operation to provide specific parameters for packaging a quality measure with its related artifacts. See the [Packaging](packaging.html) discussion for more information.
 
 | **Operation** | **Description** |
 |----|----|

--- a/input/pages/packaging.md
+++ b/input/pages/packaging.md
@@ -2,7 +2,7 @@
 
 {: #measure-packaging}
 
-To facilitate publishing and distribution of quality measures, this Implementation Guide provides guidance on how to package quality measures, either independently, or as part of a collection of related measures.
+Packaging provides a standardized mechanism for exchanging quality measures together with their dependent artifacts. Packaged measures may be produced or consumed by measure authoring environments, repositories, quality reporting systems, testing frameworks, and implementation tooling to support publication, distribution, implementation, validation, testing, and lifecycle management. By exchanging all required artifacts as a single package, implementers can more consistently deploy and evaluate quality measures across interoperable systems.
 
 Measure packages are a special case of the more general [Artifact Packaging]({{site.data.fhir.ver.crmi}}/packaging.html) capability described in the Canonical Resource Management Infrastructure (CRMI) implementation guide. Measures may be packaged using that approach, with additional considerations as discussed in the following topics.
 
@@ -54,17 +54,17 @@ The following are conformance requirements when packaging a Measure:
   4. Measure bundles MAY include any code systems and value sets referenced by the primary library or any required libraries.
   5. Measure bundles MAY include any test case bundles defined for the measure
   6. If the capabilities parameter of the package request includes `computable`:
-      a. The Measure resource SHALL conform to the [CQMComputableMeasure](StructureDefinition-cqm-computablemeasure.html) profile.
-      b. The Library resource(s) SHALL conform to the [CRMIComputableLibrary]({{site.data.fhir.ver.crmi}}/StructureDefinition-crmi-computablelibrary.html) profile.
-      b. For Measures using CQL:
-          i. The Measure resource SHALL conform to the [CQLMeasure](StructureDefinition-cqm-cqlmeasure.html) profile.
-          ii. The Library resource(s) SHALL conform to the [CQLLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-cql-library.html)
+     1. The Measure resource SHALL conform to the [CQMComputableMeasure](StructureDefinition-cqm-computablemeasure.html) profile.
+     2. The Library resource(s) SHALL conform to the [CRMIComputableLibrary]({{site.data.fhir.ver.crmi}}/StructureDefinition-crmi-computablelibrary.html) profile
+     3. For Measures using CQL:
+        1. The Measure resource SHALL conform to the [CQLMeasure](StructureDefinition-cqm-cqlmeasure.html) profile.
+        2. The Library resource(s) SHALL conform to the [CQLLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-cql-library.html)
   7. If the capabilities parameter of the package request includes `executable`: 
-      a. The Measure resource SHALL conform to the [CQMExecutableMeasure](StructureDefinition-cqm-executablemeasure.html) profile.
-      b. The Library resource(s) SHALL conform to the [CRMIExecutableLibrary]({{site.data.fhir.ver.crmi}}/StructureDefinition-crmi-executablelibrary.html) profile.
-      a. For Measures using CQL
-          i. The Measure resource SHALL conform to the [ELMMeasure](StructureDefinition-cqm-elmmeasure.html) profile.
-          ii. The Library resource(s) SHALL conform to one (or both) of the [ELMXMLLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-xml-library.html) or [ELMJSONLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-json-library.html) profiles.
+      1. The Measure resource SHALL conform to the [CQMExecutableMeasure](StructureDefinition-cqm-executablemeasure.html) profile.
+      2. The Library resource(s) SHALL conform to the [CRMIExecutableLibrary]({{site.data.fhir.ver.crmi}}/StructureDefinition-crmi-executablelibrary.html) profile.
+      3. For Measures using CQL
+          1. The Measure resource SHALL conform to the [ELMMeasure](StructureDefinition-cqm-elmmeasure.html) profile.
+          2. The Library resource(s) SHALL conform to one (or both) of the [ELMXMLLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-xml-library.html) or [ELMJSONLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-json-library.html) profiles.
 
 ### Packaging Terminology
 {: #packaging-terminology}

--- a/input/pages/packaging.md
+++ b/input/pages/packaging.md
@@ -66,6 +66,68 @@ The following are conformance requirements when packaging a Measure:
           1. The Measure resource SHALL conform to the [ELMMeasure](StructureDefinition-cqm-elmmeasure.html) profile.
           2. The Library resource(s) SHALL conform to one (or both) of the [ELMXMLLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-xml-library.html) or [ELMJSONLibrary]({{site.data.fhir.ver.cql}}/StructureDefinition-elm-json-library.html) profiles.
 
+### CQM Package Operation
+{: #cqm-package-operation}
+
+A successful cqm-package operation returns a Bundle containing the requested Measure together with the dependent artifacts available on the responding server. Depending on the requested packaging options, the response may include referenced Library resources, terminology artifacts, conformance resources, test cases, examples, and other supporting knowledge artifacts required to implement and evaluate the measure. The returned Bundle provides a consistent mechanism for exchanging the complete set of artifacts necessary to support interoperable quality measure implementation. The Snippet 6-1 provides an example for the CQM Package operation.
+
+```json
+{
+  "resourceType":"Parameters",
+  "parameter":[
+    {
+      "name":"url",
+      "valueUri":"http://hl7.org/fhir/uv/cqm/Measure/EXMLogic-FHIR"
+    },
+    {
+      "name":"version",
+      "valueString":"2.0.0"
+    },
+    {
+      "name":"capability",
+      "valueString":"computable"
+    },
+    {
+      "name":"bundleType",
+      "valueCode":"collection"
+    },
+    {
+      "name":"include",
+      "valueCode":"artifact"
+    },
+    {
+      "name":"include",
+      "valueCode":"knowledge"
+    },
+    {
+      "name":"include",
+      "valueCode":"terminology"
+    },
+    {
+      "name":"include",
+      "valueCode":"profiles"
+    },
+    {
+      "name":"include",
+      "valueCode":"extensions"
+    },
+    {
+      "name":"include",
+      "valueCode":"tests"
+    },
+    {
+      "name":"packageOnly",
+      "valueBoolean":false
+    },
+    {
+      "name":"errorBehavior",
+      "valueCode":"loose"
+    }
+  ]
+}
+```
+Snippet 6-1: Example cqm-package request
+
 ### Packaging Terminology
 {: #packaging-terminology}
 

--- a/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
+++ b/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
@@ -51,14 +51,11 @@
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="A desired capability of the resulting package. `computable` to include
-computable elements in packaged content; `executable` to include executable
-elements in packaged content; `publishable` to include publishable elements in
-packaged content."/>
+    <documentation value="A desired capability of the resulting package. `computable` to include computable elements in packaged content; `executable` to include executable elements in packaged content; `publishable` to include publishable elements in packaged content."/>
     <type value="string"/>
   </parameter>
-<!--  Updated for FHIR-56819-->
-<!--  <parameter>
+  <!--  Updated for FHIR-56819-->
+  <!--  <parameter>
     <name value="canonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -69,7 +66,7 @@ the resource does not already specify a version. The format is the same as a can
 parameter to the $expand operation to apply to any canonical resource, including code systems."/>
     <type value="canonical"/>
   </parameter>-->
-<!--  <parameter>
+  <!--  <parameter>
     <name value="checkCanonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -81,7 +78,7 @@ this is a generalization of the `check-system-version` parameter to the $expand 
 apply to any canonical resource, including code systems."/>
     <type value="canonical"/>
   </parameter>-->
-<!--  <parameter>
+  <!--  <parameter>
     <name value="forceCanonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -104,7 +101,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Specifies a version to use for a canonical or artifact resource if the artifact referencing &#xA;the resource does not already specify a version. The format is the same as a canonical URL:&#xA;[url]|[version] - e.g. http://loinc.org|2.56 Note that this is a generalization of the `system-version`&#xA;parameter to the $expand operation to apply to any canonical resource, including code systems."/>
+    <documentation value="Specifies a version to use for a canonical or artifact resource if the artifact referencing &#xA;the resource does not already specify a version. The format is the same as a canonical URL:&#xA;[url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that this is a generalization of the `system-version`&#xA;parameter to the $expand operation to apply to any canonical resource, including code systems."/>
     <type value="uri"/>
   </parameter>
   <parameter>
@@ -112,7 +109,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing &#xA;the resource specifies a different version, an error is returned instead of the package. The&#xA;format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 Note that&#xA;this is a generalization of the `check-system-version` parameter to the $expand operation to &#xA;apply to any canonical resource, including code systems."/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing &#xA;the resource specifies a different version, an error is returned instead of the package. The&#xA;format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that&#xA;this is a generalization of the `check-system-version` parameter to the $expand operation to &#xA;apply to any canonical resource, including code systems."/>
     <type value="uri"/>
   </parameter>
   <parameter>
@@ -120,22 +117,16 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any&#xA;specified version in the artifact (and any artifacts it depends on). The&#xA;format is the same as a canonical URL: [system]|[version] - e.g.&#xA;http://loinc.org|2.56. Note that this has obvious safety issues, in that it may&#xA;result in a value set expansion giving a different list of codes that is both&#xA;wrong and unsafe, and implementers should only use this capability reluctantly.&#xA;It primarily exists to deal with situations where specifications have fallen&#xA;into decay as time passes. If the version of a canonical is overridden, the version used SHALL&#xA;explicitly be represented in the expansion parameters. Note that this is a generalization of the&#xA;`force-system-version` parameter to the $expand operation to apply to any canonical resource,&#xA;including code systems."/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any&#xA;specified version in the artifact (and any artifacts it depends on). The&#xA;format is the same as a canonical URL: [system]|[version] - e.g.&#xA;http://loinc.org|2.56. &#xA;&#xA;Note that this has obvious safety issues, in that it may&#xA;result in a value set expansion giving a different list of codes that is both&#xA;wrong and unsafe, and implementers should only use this capability reluctantly.&#xA;It primarily exists to deal with situations where specifications have fallen&#xA;into decay as time passes. If the version of a canonical is overridden, the version used SHALL&#xA;explicitly be represented in the expansion parameters. &#xA;&#xA;Note that this is a generalization of the&#xA;`force-system-version` parameter to the $expand operation to apply to any canonical resource,&#xA;including code systems."/>
     <type value="uri"/>
   </parameter>
-<!--  End of updates for FHIR-56819-->
+  <!--  End of updates for FHIR-56819-->
   <parameter>
     <name value="manifest"/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Specifies an asset-collection library that defines version bindings for code
-systems and other canonical resources referenced by the value set(s) being expanded
-and other canonical resources referenced by the artifact. When specified, code
-systems and other canonical resources identified as `depends-on` related artifacts
-in the manifest library have the same meaning as specifying that code system or other
-canonical version in the `system-version` parameter of an expand or the `canonicalVersion`
-parameter."/>
+    <documentation value="Specifies an asset-collection library that defines version bindings for code systems and other canonical resources referenced by the value set(s) being expanded and other canonical resources referenced by the artifact. When specified, code systems and other canonical resources identified as `depends-on` related artifacts in the manifest library have the same meaning as specifying that code system or other canonical version in the `system-version` parameter of an expand or the `canonicalVersion` parameter."/>
     <type value="canonical"/>
   </parameter>
   <parameter>
@@ -143,8 +134,7 @@ parameter."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Paging support - where to start if a subset is desired (default = 0). Offset is
-number of records (not number of pages)"/>
+    <documentation value="Paging support - where to start if a subset is desired (default = 0). Offset is number of records (not number of pages)"/>
     <type value="integer"/>
   </parameter>
   <parameter>
@@ -152,8 +142,7 @@ number of records (not number of pages)"/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Paging support - how many resources should be provided in a partial page view.
-If count = 0, the client is asking how large the package is."/>
+    <documentation value="Paging support - how many resources should be provided in a partial page view. If count = 0, the client is asking how large the package is."/>
     <type value="integer"/>
   </parameter>
   <parameter>
@@ -161,19 +150,7 @@ If count = 0, the client is asking how large the package is."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Specifies what contents should be included in the resulting package. The codes indicate which types of resources should be included, but note that
-the set of possible resources is determined as all known (i.e. present on the server) dependencies and related artifacts. Possible
-values are:
-* all (default) - all resource types
-* artifact - the specified artifact
-* canonical - canonical resources (i.e. resources with a defined url element or that can be canonical resources using the artifact-url extension)
-* terminology - terminology resources (i.e. CodeSystem, ValueSet, NamingSystem, ConceptMap)
-* conformance - conformance resources (i.e. StructureDefinition, StructureMap, SearchParameter, CompartmentDefinition)
-* profiles - profile definitions (i.e. StructureDefinition resources that define profiles)
-* extensions - extension definitions (i.e. StructureDefinition resources that define extensions)
-* knowledge - knowledge artifacts (i.e. ActivityDefinition, Library, PlanDefinition, Measure, Questionnaire)
-* tests - test cases and data (i.e. test cases as defined by the testing specification in this implementation guide)
-* examples - example resources (i.e. resources identified as examples in the implementation guide)"/>
+    <documentation value="Specifies what contents should be included in the resulting package. The codes indicate which types of resources should be included, but note that the set of possible resources is determined as all known (i.e. present on the server) dependencies and related artifacts. Possible values are:&#xA;* `all` (default) - all resource types&#xA;* `artifact` - the specified artifact&#xA;* `canonical` - canonical resources (i.e. resources with a defined url element or that can be canonical resources using the artifact-url extension)&#xA;* `terminology` - terminology resources (i.e. CodeSystem, ValueSet, NamingSystem, ConceptMap)&#xA;* `conformance` - conformance resources (i.e. StructureDefinition, StructureMap, SearchParameter, CompartmentDefinition)&#xA;* `profiles` - profile definitions (i.e. StructureDefinition resources that define profiles)&#xA;* `extensions` - extension definitions (i.e. StructureDefinition resources that define extensions)&#xA;* `knowledge` - knowledge artifacts (i.e. ActivityDefinition, Library, PlanDefinition, Measure, Questionnaire)&#xA;* `tests` - test cases and data (i.e. test cases as defined by the testing specification in this implementation guide)&#xA;* `examples` - example resources (i.e. resources identified as examples in the implementation guide)"/>
     <type value="string"/>
   </parameter>
   <parameter>
@@ -181,9 +158,7 @@ values are:
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="True to indicate that the resulting package should only include resources that are defined in the implementation guide
-or specification that defines the artifact being packaged. False (default) to indicate that the resulting package should
-include resources regardless of what implementation guide or specification they are defined in."/>
+    <documentation value="True to indicate that the resulting package should only include resources that are defined in the implementation guide or specification that defines the artifact being packaged. False (default) to indicate that the resulting package should include resources regardless of what implementation guide or specification they are defined in."/>
     <type value="boolean"/>
   </parameter>
   <parameter>
@@ -191,9 +166,7 @@ include resources regardless of what implementation guide or specification they 
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="An endpoint to use to access content (i.e. libraries, activities, measures, questionnaires, and plans) referenced by the
-artifact. If no content endpoint is supplied the evaluation will attempt to
-retrieve content from the server on which the operation is being performed."/>
+    <documentation value="An endpoint to use to access content (i.e. libraries, activities, measures, questionnaires, and plans) referenced by the artifact. If no content endpoint is supplied the evaluation will attempt to retrieve content from the server on which the operation is being performed."/>
     <type value="Endpoint"/>
   </parameter>
   <parameter>
@@ -201,13 +174,10 @@ retrieve content from the server on which the operation is being performed."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="An endpoint to use to access terminology (i.e. valuesets, codesystems, naming systems, concept maps, and
-membership testing) referenced by the Resource. If no terminology endpoint is
-supplied, the evaluation will attempt to use the server on which the operation
-is being performed as the terminology server."/>
+    <documentation value="An endpoint to use to access terminology (i.e. valuesets, codesystems, naming systems, concept maps, and membership testing) referenced by the Resource. If no terminology endpoint is supplied, the evaluation will attempt to use the server on which the operation is being performed as the terminology server."/>
     <type value="Endpoint"/>
   </parameter>
-  
+
   <!--  New IN parameters for FHIR-56819  -->
   <parameter>
     <name value="terminologyCapabilities"/>
@@ -262,19 +232,13 @@ is being performed as the terminology server."/>
     </part>
   </parameter>
   <!-- End of New parameters for FHIR-56819  -->
-  
+
   <parameter>
     <name value="return"/>
     <use value="out"/>
     <min value="1"/>
     <max value="1"/>
-    <documentation value="The result of the packaging. Servers generating packages SHALL include all the
-dependency resources referenced by the artifact that are known to the server and
-specified by the include parameters.
-
-For example, a measure repository SHALL include
-all the required library resources, but would not necessarily have the
-ValueSet resources referenced by the measure."/>
+    <documentation value="The result of the packaging. Servers generating packages SHALL include all the dependency resources referenced by the artifact that are known to the server and specified by the include parameters. &#xA;*&#xA;*For example, a measure repository SHALL include all the required library resources, but would not necessarily have the ValueSet resources referenced by the measure."/>
     <type value="Bundle"/>
   </parameter>
 </OperationDefinition>

--- a/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
+++ b/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
@@ -101,7 +101,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Specifies a version to use for a canonical or artifact resource if the artifact referencing &#xA;the resource does not already specify a version. The format is the same as a canonical URL:&#xA;[url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that this is a generalization of the `system-version`&#xA;parameter to the $expand operation to apply to any canonical resource, including code systems."/>
+    <documentation value="Specifies a version to use for a canonical or artifact resource if the artifact referencing the resource does not already specify a version. The format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that this is a generalization of the `system-version` parameter to the $expand operation to apply to any canonical resource, including code systems."/>
     <type value="uri"/>
   </parameter>
   <parameter>
@@ -109,7 +109,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing &#xA;the resource specifies a different version, an error is returned instead of the package. The&#xA;format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that&#xA;this is a generalization of the `check-system-version` parameter to the $expand operation to &#xA;apply to any canonical resource, including code systems."/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing the resource specifies a different version, an error is returned instead of the package. The format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 &#xA;&#xA;Note that this is a generalization of the `check-system-version` parameter to the $expand operation to  apply to any canonical resource, including code systems."/>
     <type value="uri"/>
   </parameter>
   <parameter>
@@ -117,7 +117,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any&#xA;specified version in the artifact (and any artifacts it depends on). The&#xA;format is the same as a canonical URL: [system]|[version] - e.g.&#xA;http://loinc.org|2.56. &#xA;&#xA;Note that this has obvious safety issues, in that it may&#xA;result in a value set expansion giving a different list of codes that is both&#xA;wrong and unsafe, and implementers should only use this capability reluctantly.&#xA;It primarily exists to deal with situations where specifications have fallen&#xA;into decay as time passes. If the version of a canonical is overridden, the version used SHALL&#xA;explicitly be represented in the expansion parameters. &#xA;&#xA;Note that this is a generalization of the&#xA;`force-system-version` parameter to the $expand operation to apply to any canonical resource,&#xA;including code systems."/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any specified version in the artifact (and any artifacts it depends on). The format is the same as a canonical URL: [system]|[version] - e.g. http://loinc.org|2.56. &#xA;&#xA;Note that this has obvious safety issues, in that it may result in a value set expansion giving a different list of codes that is both wrong and unsafe, and implementers **SHOULD** only use this capability reluctantly. It primarily exists to deal with situations where specifications have fallen into decay as time passes. If the version of a canonical is overridden, the version used **SHALL** explicitly be represented in the expansion parameters. &#xA;&#xA;Note that this is a generalization of the `force-system-version` parameter to the $expand operation to apply to any canonical resource, including code systems."/>
     <type value="uri"/>
   </parameter>
   <!--  End of updates for FHIR-56819-->
@@ -142,7 +142,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Paging support - how many resources should be provided in a partial page view. If count = 0, the client is asking how large the package is."/>
+    <documentation value="Paging support - how many resources **SHOULD** be provided in a partial page view. If count = 0, the client is asking how large the package is."/>
     <type value="integer"/>
   </parameter>
   <parameter>
@@ -150,7 +150,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Specifies what contents should be included in the resulting package. The codes indicate which types of resources should be included, but note that the set of possible resources is determined as all known (i.e. present on the server) dependencies and related artifacts. Possible values are:&#xA;* `all` (default) - all resource types&#xA;* `artifact` - the specified artifact&#xA;* `canonical` - canonical resources (i.e. resources with a defined url element or that can be canonical resources using the artifact-url extension)&#xA;* `terminology` - terminology resources (i.e. CodeSystem, ValueSet, NamingSystem, ConceptMap)&#xA;* `conformance` - conformance resources (i.e. StructureDefinition, StructureMap, SearchParameter, CompartmentDefinition)&#xA;* `profiles` - profile definitions (i.e. StructureDefinition resources that define profiles)&#xA;* `extensions` - extension definitions (i.e. StructureDefinition resources that define extensions)&#xA;* `knowledge` - knowledge artifacts (i.e. ActivityDefinition, Library, PlanDefinition, Measure, Questionnaire)&#xA;* `tests` - test cases and data (i.e. test cases as defined by the testing specification in this implementation guide)&#xA;* `examples` - example resources (i.e. resources identified as examples in the implementation guide)"/>
+    <documentation value="Specifies what contents **SHOULD** be included in the resulting package. The codes indicate which types of resources **SHOULD** be included, but note that the set of possible resources is determined as all known (i.e. present on the server) dependencies and related artifacts. Possible values are:&#xA;* `all` (default) - all resource types&#xA;* `artifact` - the specified artifact&#xA;* `canonical` - canonical resources (i.e. resources with a defined url element or that can be canonical resources using the artifact-url extension)&#xA;* `terminology` - terminology resources (i.e. CodeSystem, ValueSet, NamingSystem, ConceptMap)&#xA;* `conformance` - conformance resources (i.e. StructureDefinition, StructureMap, SearchParameter, CompartmentDefinition)&#xA;* `profiles` - profile definitions (i.e. StructureDefinition resources that define profiles)&#xA;* `extensions` - extension definitions (i.e. StructureDefinition resources that define extensions)&#xA;* `knowledge` - knowledge artifacts (i.e. ActivityDefinition, Library, PlanDefinition, Measure, Questionnaire)&#xA;* `tests` - test cases and data (i.e. test cases as defined by the testing specification in this implementation guide)&#xA;* `examples` - example resources (i.e. resources identified as examples in the implementation guide)"/>
     <type value="string"/>
   </parameter>
   <parameter>
@@ -158,7 +158,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="True to indicate that the resulting package should only include resources that are defined in the implementation guide or specification that defines the artifact being packaged. False (default) to indicate that the resulting package should include resources regardless of what implementation guide or specification they are defined in."/>
+    <documentation value="True to indicate that the resulting package **SHOULD** only include resources that are defined in the implementation guide or specification that defines the artifact being packaged. False (default) to indicate that the resulting package **SHOULD** include resources regardless of what implementation guide or specification they are defined in."/>
     <type value="boolean"/>
   </parameter>
   <parameter>
@@ -184,7 +184,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="A TerminologyCapabilities resource describing the expected terminology capabilities &#xA;of the target environment. For example, an environment may be capable of processing &#xA;specific types of value set definitions, but not others (e.g. LOINC panel definitions, &#xA;but not SNOMED hierarchies)."/>
+    <documentation value="A TerminologyCapabilities resource describing the expected terminology capabilities  of the target environment. For example, an environment may be capable of processing  specific types of value set definitions, but not others (e.g. LOINC panel definitions,  but not SNOMED hierarchies)."/>
     <type value="TerminologyCapabilities"/>
   </parameter>
   <parameter>
@@ -192,7 +192,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Indicates the request method (POST or PUT) that should be used for entries in the resulting package bundle. If not specified, the request method is at the discretion of the server."/>
+    <documentation value="Indicates the request method (POST or PUT) that **SHOULD** be used for entries in the resulting package bundle. If not specified, the request method is at the discretion of the server."/>
     <type value="code"/>
   </parameter>
   <parameter>
@@ -200,7 +200,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="Determines the type of the output Bundle, may be either collection, or transaction.&#xA;If not specified, the output bundle will be a transaction bundle, unless paging is used,&#xA;or determined to be necessary by the server.&#xA;&#xA;If paging is used, the bundle type SHALL be&#xA;searchset, and the resulting bundles SHALL conform to the paging guidance here: https://hl7.org/fhir/R4/http.html#paging&#xA;&#xA;It is an error to request a transaction or collection bundle and use paging. Servers are &#xA;free to return a TOO-COSTLY error if a transaction or collection bundle is requested for&#xA;a package that is deemed to be too large by the server."/>
+    <documentation value="Determines the type of the output Bundle, **MAY** be either collection, or transaction. If not specified, the output bundle will be a transaction bundle, unless paging is used, or determined to be necessary by the server.&#xA;&#xA;If paging is used, the bundle type **SHALL** be searchset, and the resulting bundles **SHALL** conform to the paging guidance here: https://hl7.org/fhir/R4/http.html#paging&#xA;&#xA;It is an error to request a transaction or collection bundle and use paging. Servers are  free to return a TOO-COSTLY error if a transaction or collection bundle is requested for a package that is deemed to be too large by the server."/>
     <type value="code"/>
   </parameter>
   <parameter>
@@ -208,7 +208,7 @@ including code systems."/>
     <use value="in"/>
     <min value="0"/>
     <max value="*"/>
-    <documentation value="Configuration information to resolve canonical artifacts&#xA;* `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)&#xA;* `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter&#xA;* `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter&#xA;&#xA;**Processing semantics**:&#xA;&#xA;Create a canonical-like reference (e.g.&#xA;`{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).&#xA;&#xA;* Given a single `artifactEndpointConfiguration`&#xA;  * When `artifactRoute` is present&#xA;    * And canonical or artifact reference *starts with* `artifactRoute`&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;  * When `artifactRoute` is not present&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;* Given multiple `artifactEndpointConfiguration`s&#xA;  * Then rank order each configuration (see below)&#xA;  * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved&#xA;&#xA;Rank each `artifactEndpointConfiguration` such that:&#xA;* if `artifactRoute` is present *and* canonical or artifact reference *starts with* `artifactRoute`: rank based on number of matching characters &#xA;* if `artifactRoute` is *not* present: include but rank lower&#xA;&#xA;NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the&#xA;OperationDefinition."/>
+    <documentation value="Configuration information to resolve canonical artifacts&#xA;* `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)&#xA;* `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter&#xA;* `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter&#xA;&#xA;**Processing semantics**:&#xA;&#xA;Create a canonical-like reference (e.g. `{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).&#xA;&#xA;* Given a single `artifactEndpointConfiguration`&#xA;  * When `artifactRoute` is present&#xA;    * And canonical or artifact reference *starts with* `artifactRoute`&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;  * When `artifactRoute` is not present&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;* Given multiple `artifactEndpointConfiguration`s&#xA;  * Then rank order each configuration (see below)&#xA;  * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved&#xA;&#xA;Rank each `artifactEndpointConfiguration` such that:&#xA;* if `artifactRoute` is present *and* canonical or artifact reference *starts with* `artifactRoute`: rank based on number of matching characters &#xA;* if `artifactRoute` is *not* present: include but rank lower&#xA;&#xA;NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the&#xA;OperationDefinition."/>
     <part>
       <name value="artifactRoute"/>
       <use value="in"/>
@@ -238,7 +238,7 @@ including code systems."/>
     <use value="out"/>
     <min value="1"/>
     <max value="1"/>
-    <documentation value="The result of the packaging. Servers generating packages SHALL include all the dependency resources referenced by the artifact that are known to the server and specified by the include parameters. &#xA;*&#xA;*For example, a measure repository SHALL include all the required library resources, but would not necessarily have the ValueSet resources referenced by the measure."/>
+    <documentation value="The result of the packaging. Servers generating packages **SHALL** include all the dependency resources referenced by the artifact that are known to the server and specified by the include parameters. &#xA;&#xA;For example, a measure repository **SHALL** include all the required library resources, but would not necessarily have the ValueSet resources referenced by the measure."/>
     <type value="Bundle"/>
   </parameter>
 </OperationDefinition>

--- a/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
+++ b/input/resources/operationdefinition/OperationDefinition-cqm-package.xml
@@ -57,7 +57,8 @@ elements in packaged content; `publishable` to include publishable elements in
 packaged content."/>
     <type value="string"/>
   </parameter>
-  <parameter>
+<!--  Updated for FHIR-56819-->
+<!--  <parameter>
     <name value="canonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -67,8 +68,8 @@ the resource does not already specify a version. The format is the same as a can
 [url]|[version] - e.g. http://loinc.org|2.56 Note that this is a generalization of the `system-version`
 parameter to the $expand operation to apply to any canonical resource, including code systems."/>
     <type value="canonical"/>
-  </parameter>
-  <parameter>
+  </parameter>-->
+<!--  <parameter>
     <name value="checkCanonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -79,8 +80,8 @@ format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2
 this is a generalization of the `check-system-version` parameter to the $expand operation to
 apply to any canonical resource, including code systems."/>
     <type value="canonical"/>
-  </parameter>
-  <parameter>
+  </parameter>-->
+<!--  <parameter>
     <name value="forceCanonicalVersion"/>
     <use value="in"/>
     <min value="0"/>
@@ -97,7 +98,32 @@ explicitly be represented in the expansion parameters. Note that this is a gener
 `force-system-version` parameter to the $expand operation to apply to any canonical resource,
 including code systems."/>
     <type value="canonical"/>
+  </parameter>-->
+  <parameter>
+    <name value="artifactVersion"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="*"/>
+    <documentation value="Specifies a version to use for a canonical or artifact resource if the artifact referencing &#xA;the resource does not already specify a version. The format is the same as a canonical URL:&#xA;[url]|[version] - e.g. http://loinc.org|2.56 Note that this is a generalization of the `system-version`&#xA;parameter to the $expand operation to apply to any canonical resource, including code systems."/>
+    <type value="uri"/>
   </parameter>
+  <parameter>
+    <name value="checkArtifactVersion"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="*"/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing &#xA;the resource specifies a different version, an error is returned instead of the package. The&#xA;format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 Note that&#xA;this is a generalization of the `check-system-version` parameter to the $expand operation to &#xA;apply to any canonical resource, including code systems."/>
+    <type value="uri"/>
+  </parameter>
+  <parameter>
+    <name value="forceArtifactVersion"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="*"/>
+    <documentation value="Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any&#xA;specified version in the artifact (and any artifacts it depends on). The&#xA;format is the same as a canonical URL: [system]|[version] - e.g.&#xA;http://loinc.org|2.56. Note that this has obvious safety issues, in that it may&#xA;result in a value set expansion giving a different list of codes that is both&#xA;wrong and unsafe, and implementers should only use this capability reluctantly.&#xA;It primarily exists to deal with situations where specifications have fallen&#xA;into decay as time passes. If the version of a canonical is overridden, the version used SHALL&#xA;explicitly be represented in the expansion parameters. Note that this is a generalization of the&#xA;`force-system-version` parameter to the $expand operation to apply to any canonical resource,&#xA;including code systems."/>
+    <type value="uri"/>
+  </parameter>
+<!--  End of updates for FHIR-56819-->
   <parameter>
     <name value="manifest"/>
     <use value="in"/>
@@ -181,6 +207,62 @@ supplied, the evaluation will attempt to use the server on which the operation
 is being performed as the terminology server."/>
     <type value="Endpoint"/>
   </parameter>
+  
+  <!--  New IN parameters for FHIR-56819  -->
+  <parameter>
+    <name value="terminologyCapabilities"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="1"/>
+    <documentation value="A TerminologyCapabilities resource describing the expected terminology capabilities &#xA;of the target environment. For example, an environment may be capable of processing &#xA;specific types of value set definitions, but not others (e.g. LOINC panel definitions, &#xA;but not SNOMED hierarchies)."/>
+    <type value="TerminologyCapabilities"/>
+  </parameter>
+  <parameter>
+    <name value="requestMethod"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="1"/>
+    <documentation value="Indicates the request method (POST or PUT) that should be used for entries in the resulting package bundle. If not specified, the request method is at the discretion of the server."/>
+    <type value="code"/>
+  </parameter>
+  <parameter>
+    <name value="bundleType"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="1"/>
+    <documentation value="Determines the type of the output Bundle, may be either collection, or transaction.&#xA;If not specified, the output bundle will be a transaction bundle, unless paging is used,&#xA;or determined to be necessary by the server.&#xA;&#xA;If paging is used, the bundle type SHALL be&#xA;searchset, and the resulting bundles SHALL conform to the paging guidance here: https://hl7.org/fhir/R4/http.html#paging&#xA;&#xA;It is an error to request a transaction or collection bundle and use paging. Servers are &#xA;free to return a TOO-COSTLY error if a transaction or collection bundle is requested for&#xA;a package that is deemed to be too large by the server."/>
+    <type value="code"/>
+  </parameter>
+  <parameter>
+    <name value="artifactEndpointConfiguration"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="*"/>
+    <documentation value="Configuration information to resolve canonical artifacts&#xA;* `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)&#xA;* `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter&#xA;* `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter&#xA;&#xA;**Processing semantics**:&#xA;&#xA;Create a canonical-like reference (e.g.&#xA;`{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).&#xA;&#xA;* Given a single `artifactEndpointConfiguration`&#xA;  * When `artifactRoute` is present&#xA;    * And canonical or artifact reference *starts with* `artifactRoute`&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;  * When `artifactRoute` is not present&#xA;    * Then attempt to resolve with `endpointUri` or `endpoint`&#xA;* Given multiple `artifactEndpointConfiguration`s&#xA;  * Then rank order each configuration (see below)&#xA;  * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved&#xA;&#xA;Rank each `artifactEndpointConfiguration` such that:&#xA;* if `artifactRoute` is present *and* canonical or artifact reference *starts with* `artifactRoute`: rank based on number of matching characters &#xA;* if `artifactRoute` is *not* present: include but rank lower&#xA;&#xA;NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the&#xA;OperationDefinition."/>
+    <part>
+      <name value="artifactRoute"/>
+      <use value="in"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type value="uri"/>
+    </part>
+    <part>
+      <name value="endpointUri"/>
+      <use value="in"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type value="uri"/>
+    </part>
+    <part>
+      <name value="endpoint"/>
+      <use value="in"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type value="Endpoint"/>
+    </part>
+  </parameter>
+  <!-- End of New parameters for FHIR-56819  -->
+  
   <parameter>
     <name value="return"/>
     <use value="out"/>


### PR DESCRIPTION
[FHIR-56819](https://jira.hl7.org/browse/FHIR-56819): CQM Package should contain examples

1. Updated Operations page text
2. Updated OperationDefinition-cqm-package:
      - Added/aligned select parameters from OperationDefinition-crmi-package
      - Updated documentation values for easier reading
3. Updated Packaging page 
      - Updated text
      - Adjusted formatting/bullets for #6 and #7 in packaging.html#conformance-requirement-6-2. **_NOTE_** that the preferred numbering style of 6.a.i does not seem to work in these .md file numbered lists, so used the style 6.1.1 instead.
      - Add a new section titled “CQM Package Operation”
      - Added json Snippet 6-1 Example cqm-package request

**DID NOT** update the IG dependency to CRMI 2.0.0, as this seems to require updating other profiles.